### PR TITLE
Request to add coursdiderot.com

### DIFF
--- a/lib/domains/com/coursdiderot.txt
+++ b/lib/domains/com/coursdiderot.txt
@@ -1,0 +1,4 @@
+the school official full name, no abbreviations please : Cours Diderot
+the school official website URL : https://www.coursdiderot.fr/
+the school street address, including city and country : La page contact avec les adresses de tous nos campus : https://www.coursdiderot.fr/contact/
+an URL of a page on the official website where the school offers an IT-related long-term (>1 year) course : https://www.coursdiderot.fr/bts-services-informatiques-organisations/


### PR DESCRIPTION
the school official full name, no abbreviations please : Cours Diderot
the school official website URL : https://www.coursdiderot.fr/
the school street address, including city and country : La page contact avec les adresses de tous nos campus : https://www.coursdiderot.fr/contact/
an URL of a page on the official website where the school offers an IT-related long-term (>1 year) course : https://www.coursdiderot.fr/bts-services-informatiques-organisations/